### PR TITLE
fix handling of unbalanced end and if/for/...

### DIFF
--- a/syntax/block_scanner.go
+++ b/syntax/block_scanner.go
@@ -53,7 +53,7 @@ func (s *blockScanner) nextToken(outVal *tokenValue) Token {
 
 func (s *blockScanner) nextTokenInner() blockScannerToken {
 	if s.matchesNewBlock() {
-		return s.buildIndent(s.prevTokens[len(s.prevTokens)-1])
+		return s.buildIndent()
 	}
 
 	var currToken blockScannerToken
@@ -146,8 +146,8 @@ func (s *blockScanner) swallowNextToken(tok Token) {
 	}
 }
 
-func (s *blockScanner) buildIndent(token blockScannerToken) blockScannerToken {
-	s.indentStack = append(s.indentStack, token)
+func (s *blockScanner) buildIndent() blockScannerToken {
+	s.indentStack = append(s.indentStack, s.prevTokens[len(s.prevTokens)-1])
 	return blockScannerToken{
 		tok: Token(INDENT),
 		val: tokenValue{pos: s.prevTokens[len(s.prevTokens)-1].val.pos},
@@ -155,7 +155,7 @@ func (s *blockScanner) buildIndent(token blockScannerToken) blockScannerToken {
 }
 
 func (s *blockScanner) buildOutdent() blockScannerToken {
-	if len(s.indentStack) < 1 {
+	if len(s.indentStack) == 0 {
 		s.error(s.getPos(), "unexpected end")
 	}
 	s.indentStack = s.indentStack[:len(s.indentStack)-1]

--- a/syntax/block_scanner.go
+++ b/syntax/block_scanner.go
@@ -20,11 +20,11 @@ type scannerInterface interface {
 // blockScanner changes INDENT/OUTDENT to be
 // based on nesting depth (start->end) instead of whitespace
 type blockScanner struct {
-	scanner *scanner
-	nextTokens []blockScannerToken
-	prevTokens []blockScannerToken
-	depth int
-	debug bool
+	scanner     *scanner
+	nextTokens  []blockScannerToken
+	prevTokens  []blockScannerToken
+	indentStack []blockScannerToken
+	debug       bool
 }
 
 var _ scannerInterface = &blockScanner{}
@@ -36,7 +36,7 @@ type blockScannerToken struct {
 }
 
 func newBlockScanner(s *scanner) *blockScanner {
-	return &blockScanner{s, nil, nil, 0, false}
+	return &blockScanner{s, nil, nil, nil, false}
 }
 
 func (s *blockScanner) nextToken(outVal *tokenValue) Token {
@@ -53,7 +53,7 @@ func (s *blockScanner) nextToken(outVal *tokenValue) Token {
 
 func (s *blockScanner) nextTokenInner() blockScannerToken {
 	if s.matchesNewBlock() {
-		return s.buildIndent()
+		return s.buildIndent(s.prevTokens[len(s.prevTokens)-1])
 	}
 
 	var currToken blockScannerToken
@@ -116,8 +116,9 @@ func (s *blockScanner) nextTokenInner() blockScannerToken {
 		}
 
 	case EOF:
-		if s.depth != 0 {
-			s.errorf(s.getPos(), "mismatched set of block openings (if/else/elif/for/def) and closing (end)")
+		if len(s.indentStack) != 0 {
+			pos := s.indentStack[len(s.indentStack)-1].val.pos
+			s.errorf(pos, "mismatched set of block openings (if/else/elif/for/def) and closing (end)")
 		}
 
 	default:
@@ -145,8 +146,8 @@ func (s *blockScanner) swallowNextToken(tok Token) {
 	}
 }
 
-func (s *blockScanner) buildIndent() blockScannerToken {
-	s.depth+=1
+func (s *blockScanner) buildIndent(token blockScannerToken) blockScannerToken {
+	s.indentStack = append(s.indentStack, token)
 	return blockScannerToken{
 		tok: Token(INDENT),
 		val: tokenValue{pos: s.prevTokens[len(s.prevTokens)-1].val.pos},
@@ -154,7 +155,10 @@ func (s *blockScanner) buildIndent() blockScannerToken {
 }
 
 func (s *blockScanner) buildOutdent() blockScannerToken {
-	s.depth-=1
+	if len(s.indentStack) < 1 {
+		s.error(s.getPos(), "unexpected end")
+	}
+	s.indentStack = s.indentStack[:len(s.indentStack)-1]
 	return blockScannerToken{
 		tok: Token(OUTDENT),
 		val: tokenValue{pos: s.prevTokens[len(s.prevTokens)-1].val.pos},


### PR DESCRIPTION
For unbalanced end and if/for/... there are two cases:
1. less closing (end) than opening (if, for, ...) keywords
1. more closing (end) than opening (if, for, ...) keywords

Currently, ytt reports case 1 at the end of the file (last non-comment line) and case 2 on the next non-comment line after the end keyword with the error message is `got outdent, want primary expression`.

With this change:
- case 1 will be reported at the unmatched opening keyword
- case 2 will be reported at the end keyword